### PR TITLE
feat(DPD-40624): added test ids for automation testing

### DIFF
--- a/src/components/primitives/Checkbox/Checkbox.tsx
+++ b/src/components/primitives/Checkbox/Checkbox.tsx
@@ -161,6 +161,10 @@ const CheckboxComponent = React.memo(
       'accessibilityHint',
     ]);
 
+    const testID =
+      resolvedProps?.testID ||
+      `checkboxItemTestID${_text || resolvedProps?.accessibilityLabel}`;
+
     //TODO: refactor for responsive prop
     if (useHasResponsiveProps(resolvedProps)) {
       return null;
@@ -190,6 +194,7 @@ const CheckboxComponent = React.memo(
           composeEventHandlers(onBlur, focusProps.onBlur)
           // focusRingProps.onBlur
         )}
+        testID={`pressableItem:${testID}`}
       >
         <Stack {...layoutProps} {..._stack}>
           <Center>

--- a/src/components/primitives/Radio/Radio.tsx
+++ b/src/components/primitives/Radio/Radio.tsx
@@ -90,6 +90,12 @@ const RadioComponent = memo(
         '_text',
       ]);
 
+      const testID =
+        resolvedProps?.testID ||
+        `radioItemTestID${
+          resolvedProps.value || resolvedProps.accessibilityLabel
+        }`;
+
       // only calling below function when icon exist.
       const sizedIcon = () =>
         //@ts-ignore
@@ -123,6 +129,7 @@ const RadioComponent = memo(
             composeEventHandlers(onBlur, focusProps.onBlur)
             // focusRingProps.onBlur
           )}
+          testID={`pressableItem:${testID}`}
         >
           <Stack {..._stack}>
             <Center>

--- a/src/components/primitives/Select/Select.tsx
+++ b/src/components/primitives/Select/Select.tsx
@@ -155,6 +155,10 @@ const Select = (
     'opacity',
   ]);
 
+  const testID =
+    resolvedProps?.testID ||
+    `selectTestID${placeholder || defaultValue || accessibilityLabel}`;
+
   const commonInput = (
     <Input
       placeholder={placeholder}
@@ -188,6 +192,7 @@ const Select = (
         accessibilityRole="button"
         ref={mergeRefs([ref, _ref])}
         {...layoutProps}
+        testID={`pressableItem:${testID}`}
       >
         {commonInput}
       </Pressable>


### PR DESCRIPTION
Add support for test ids for the following components `Checkbox`, `Radio`, and `Select`. 
The scope of this PR is to make the resourceID visible to the automation testing team, by adding testID to the react-native components.